### PR TITLE
Locking the installer

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -35,6 +35,7 @@ var puppet = {
   line: 0,
   interval: 700,
   url: 'puppet',
+  cleanup: 'cleanup',
   set_progress: function(p) {
     puppet.progress = p;
     $('#progressbar>span').width(p+'%');
@@ -120,6 +121,7 @@ var puppet = {
   complete: function() {
     $('#page-puppet').removeClass('progress');
     $('#puppet-done').show(); 
+    $.get(puppet.cleanup);
   },
   init: function() {
     $('#page-puppet').addClass('progress');

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author='',
     author_email='',
     install_requires=[
-        "pecan"
+        "pecan", "pyyaml"
     ],
     test_suite='st2installer',
     zip_safe=False,

--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -45,12 +45,17 @@ class RootController(object):
 
   @expose(generic=True, template='index.html')
   def index(self):
+    if self.proc:
+      redirect('/install', internal=True)
     return dict()
 
-  @index.when(method='POST', template='progress.html')
+  @index.when(method='POST')
   def index_post(self, **kwargs):
 
-    temp = dict(keyfallback = False, kwargs=kwargs)
+    if self.proc:
+      redirect('/install', internal=True)
+
+    keyfallback = False
 
     password_length = 32
     password_chars = string.ascii_letters + string.digits + '!@#$%^&*()'
@@ -104,7 +109,7 @@ class RootController(object):
         config["st2::ssl_public_key"] = request.POST['file-publickey'].file.read()
         config["st2::ssl_private_key"] = request.POST['file-privatekey'].file.read()
       else:
-        temp['keyfallback'] = True
+        keyfallback = True
 
     if kwargs["chatops"] == "example":
       config["hubot::adapter"] = "irc"
@@ -166,8 +171,8 @@ class RootController(object):
     with open(path+filename, 'w') as workroom:
       workroom.write(yaml.dump(config))
 
-    return temp
+    redirect('/install%s' % ('?key=fallback' if keyfallback else ''), internal=True)
 
-  @expose(generic=True, template='final.html')
-  def done(self):
-    return dict()
+  @expose(generic=True, template='progress.html')
+  def install(self):
+    return dict(keyfallback = request.GET.get('key'))

--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -23,6 +23,11 @@ class RootController(object):
   output = '/tmp/st2installer.log'
 
   @expose(content_type='text/plain')
+  def cleanup(self):
+    Popen("/bin/echo whee!", shell=True)
+    return "done"
+
+  @expose(content_type='text/plain')
   def puppet(self, line):
     if not self.proc:
       open(self.output, 'w').close()

--- a/st2installer/templates/progress.html
+++ b/st2installer/templates/progress.html
@@ -5,7 +5,7 @@
 <div class="page" id="page-puppet">
   <h1>Installation</h1>
   <p>StackStorm is preparing for the first launch! Installation will take a few more minutes.</p>
-  % if keyfallback == True:
+  % if keyfallback == 'fallback':
     <p>SSH keys are not valid, reverting to a self-signed certificate.</p>
   % endif
   <div id="warning-count">

--- a/test/output.py
+++ b/test/output.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import sys, random, time
 
 # A sample app for UI testing that just throws some output to stdout and stderr.
@@ -31,4 +33,5 @@ for line in range(total_lines):
   if line>0 and not (line % (total_lines/5)):
     sys.stdout.write("PROGRESS: %i\n" % (100/float(total_lines)*line))
   sys.stdout.write("%s\n" % sb)
+  sys.stdout.flush()
   time.sleep(line_pause)


### PR DESCRIPTION
1. The installer is locked right after puppet has started: every page request redirects into the installation page so that configuration can't be changed after puppet starts.
2. There's a cleanup hook to remove the installer after puppet has finished.