### PR TITLE
Key pair validation/generation

### DIFF
--- a/keycompare
+++ b/keycompare
@@ -1,0 +1,15 @@
+#!/bin/bash
+PRIVKEY=/tmp/testkey
+TESTKEY=/tmp/testkey-pub
+if test ! -r /tmp/testkey || test ! -r /tmp/testkey
+then
+  echo "1"
+  exit
+fi
+chmod 600 "$PRIVKEY"
+chmod 600 "$TESTKEY"
+diff -q <( ssh-keygen -y -e -f "$PRIVKEY" -P "" ) <( ssh-keygen -y -e -f "$TESTKEY" -P "" )
+STATUS=$?
+rm -f "$PRIVKEY"
+rm -f "$TESTKEY"
+echo "$STATUS"

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -405,6 +405,8 @@ var installer = {
   submit: function() {
     if (installer.page == $('.page').length-1) {
       installer.validate(installer.page, function() {
+        $('#installer').removeAttr("target");
+        $('#installer').removeAttr("action");
         $('#installer').submit();
       });
     } else {

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -125,15 +125,18 @@ h1, h2, h3, h4, h5, h6 {
   width: 960px;
   margin: auto;
 }
-.page h1 {
+.page h1,
+#modal h1 {
   font-size: 32px;
   margin: 30px 0 20px;
 }
-.page h2 {
+.page h2,
+#modal h2 {
   font-size: 24px;
   margin: 20px 0 10px;
 }
-.page label {
+.page label,
+#modal label {
   display: block;
   margin: 5px 0;
   font-size: 16px;
@@ -146,7 +149,8 @@ h1, h2, h3, h4, h5, h6 {
   position: relative;
   top: -2px;
 }
-.page p {
+.page p,
+#modal p {
   background-color: #252525;
   padding: 10px;
   border-radius: 5px;
@@ -183,13 +187,15 @@ textarea {
   resize: none;
   margin-bottom: 10px;
 }
-.page fieldset#ssl div {
+.page fieldset#ssl div,
+.page fieldset#ssh div {
   float: left;
   margin-right: 20px;
   margin-top: 10px;
   width: 470px;
 }
-.page fieldset#ssl div:last-child {
+.page fieldset#ssl div:last-child,
+.page fieldset#ssh div:last-child {
   margin-right: 0;
 }
 #chatops-navigation {
@@ -263,7 +269,8 @@ textarea {
   font-family: Oswald;
   font-weight: 200;
 }
-#next-button a {
+#next-button a,
+#modal-buttons a {
   float: right;
   font-family: Oswald;
   font-weight: 200;
@@ -283,7 +290,8 @@ textarea {
   text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
   text-decoration: none;
 }
-#ssl {
+#ssl,
+#ssh {
   display: none;
 }
 p.hint,
@@ -334,7 +342,8 @@ p.hint,
   color: #880000;
   margin-top: 7px;
 }
-#ssl+p.error {
+#ssl+p.error,
+#ssh+p.error {
   float: none;
   margin-top: 10px;
 }
@@ -480,4 +489,53 @@ label.required:after {
 #puppet-done #next-button a {
   float: none;
   margin: 0 auto;
+}
+
+#modal-overflow {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: black;
+  background: rgba(0,0,0,0.8);
+  display: none;
+}
+#modal {
+  width: 470px;
+  padding: 20px;
+  margin: 0 auto;
+  background: #1e1e1e;
+  border-radius: 5px;
+  top: 50%;
+  position: absolute;
+  left: 50%;
+  margin-left: -255px;
+}
+#modal #keypair {
+  display: none;
+}
+#modal h3 {
+  background: #ff8300;
+  color: white;
+  margin: -20px -20px 20px;
+  padding: 10px 20px;
+  border-radius: 5px 5px 0 0;
+}
+#modal textarea {
+  height: 100px;
+}
+
+#modal-buttons {
+  height: 50px;
+  text-align: center;
+  margin-bottom: -10px;
+  margin-top: 10px;
+}
+
+#modal-buttons a {
+  display: inline-block;
+  float: none;
+  margin: 0 10px;
 }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -525,6 +525,8 @@ label.required:after {
 }
 #modal textarea {
   height: 100px;
+  padding: 5px;
+  width: 458px;
 }
 
 #modal-buttons {

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author='',
     author_email='',
     install_requires=[
-        "pecan", "pyyaml"
+        "pecan", "pyyaml", "rsa"
     ],
     test_suite='st2installer',
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author='',
     author_email='',
     install_requires=[
-        "pecan", "pyyaml", "rsa"
+        "pecan", "pyyaml", "pycrypto"
     ],
     test_suite='st2installer',
     zip_safe=False,

--- a/st2installer/controllers/keypair.py
+++ b/st2installer/controllers/keypair.py
@@ -7,7 +7,7 @@ class KeypairController(object):
 
   private = '/tmp/testkey'
   public = '/tmp/testkey-pub'
-  diff = '/usr/bin/keycompare'
+  diff = '/etc/st2installer/keycompare'
   diff_output = '/tmp/keycompare.log'
 
   @expose(generic=True, content_type='text/plain')

--- a/st2installer/controllers/keypair.py
+++ b/st2installer/controllers/keypair.py
@@ -1,6 +1,7 @@
 from pecan import expose, request, Response, redirect, abort
 from subprocess import call
-import random, string, os, rsa
+import random, string, os
+from Crypto.PublicKey import RSA
 
 class KeypairController(object):
 
@@ -34,8 +35,8 @@ class KeypairController(object):
 
   @expose('json')
   def keygen(self):
-    (public, private) = rsa.newkeys(1024)
+    private = RSA.generate(1024, os.urandom)
     return {
-      'private': private.save_pkcs1(format='PEM'),
-      'public': public.save_pkcs1(format='PEM')
+      'private': private.exportKey('PEM'),
+      'public': private.publickey().exportKey('OpenSSH')
     }

--- a/st2installer/controllers/keypair.py
+++ b/st2installer/controllers/keypair.py
@@ -1,0 +1,33 @@
+from pecan import expose, request, Response, redirect, abort
+from subprocess import call
+import random, string, os
+
+class KeypairController(object):
+
+  private = '/tmp/testkey'
+  public = '/tmp/testkey-pub'
+  diff = '/usr/bin/keycompare'
+  diff_output = '/tmp/keycompare.log'
+
+  @expose(generic=True, content_type='text/plain')
+  def index(self):
+    abort(400)
+
+  @index.when(method='POST')
+  def index_post(self):
+    if request.POST['comparison'] == 'ssh':
+      private_field = 'file-ssh-privatekey'
+      public_field = 'file-ssh-publickey'
+    else:
+      private_field = 'file-privatekey'
+      public_field = 'file-publickey'
+    upload_private = request.POST[private_field]
+    upload_public = request.POST[public_field]
+    with open(self.private, 'w') as temp_private:
+      temp_private.write(upload_private.file.read())
+    with open(self.public, 'w') as temp_public:
+      temp_public.write(upload_public.file.read())
+    call("%s > %s" % (self.diff, self.diff_output), shell=True)
+    with open(self.diff_output, 'r') as output:
+      data = output.read()
+    return data

--- a/st2installer/controllers/keypair.py
+++ b/st2installer/controllers/keypair.py
@@ -1,6 +1,6 @@
 from pecan import expose, request, Response, redirect, abort
 from subprocess import call
-import random, string, os
+import random, string, os, rsa
 
 class KeypairController(object):
 
@@ -31,3 +31,11 @@ class KeypairController(object):
     with open(self.diff_output, 'r') as output:
       data = output.read()
     return data
+
+  @expose('json')
+  def keygen(self):
+    (public, private) = rsa.newkeys(1024)
+    return {
+      'private': private.save_pkcs1(format='PEM'),
+      'public': public.save_pkcs1(format='PEM')
+    }

--- a/st2installer/templates/index.html
+++ b/st2installer/templates/index.html
@@ -130,6 +130,8 @@
     <a href="#" id="step-back">Back</a>
     <p>Step <span id="current-step"></span> of <span id="total-steps"></span></p>
   </div>
+  <input type="hidden" name="gen-private" id="gen-private" value=""/>
+  <input type="hidden" name="gen-public" id="gen-public" value=""/>
   <input type="hidden" name="comparison" id="hidden-comparison" value=""/>
 </form>
 <iframe style="display:none" id="keypair-frame" name="keypair-frame"></iframe>

--- a/st2installer/templates/index.html
+++ b/st2installer/templates/index.html
@@ -3,28 +3,28 @@
 <form id="installer" method="POST" action="." enctype="multipart/form-data">
   <div class="page" id="page-hostname">
     <h1>Configure Hostname and SSL</h1>
-    
-      <label for="text-hostname" class="required">Hostname</label>
-      <input type="text" id="text-hostname" name="hostname" />
-      <p class="hint">FQDN of host.</p>
-    
-    
-      <h2>SSL keys</h2>
-      <p>By default, StackStorm installs with a self-signed SSL certificate. If you would like to provide your own certificate, you can upload it here.</p>
-      <fieldset id="ssl-enable">
-        <label for="radio-selfsigned-true"><input id="radio-selfsigned-true" type="radio" name="selfsigned" value="1" checked="checked">Continue with self-signed</label>
-        <label for="radio-selfsigned-false"><input id="radio-selfsigned-false" type="radio" name="selfsigned" value="0">Upload SSL certificate</label>
-      </fieldset>
-      <fieldset id="ssl">
-        <div>
-          <label for="textarea-public" class="required">Public key</label>
-          <input type="file" name="file-publickey" id="file-publickey" />
-        </div>
-        <div>
-          <label for="textarea-private" class="required">Private key</label>
-          <input type="file" name="file-privatekey" id="file-privatekey" />
-        </div>
-      </fieldset>
+  
+    <label for="text-hostname" class="required">Hostname</label>
+    <input type="text" id="text-hostname" name="hostname" />
+    <p class="hint">FQDN of host.</p>
+  
+  
+    <h2>SSL keys</h2>
+    <p>By default, StackStorm installs with a self-signed SSL certificate. If you would like to provide your own certificate, you can upload it here.</p>
+    <fieldset id="ssl-enable">
+      <label for="radio-selfsigned-true"><input id="radio-selfsigned-true" type="radio" name="selfsigned" value="1" checked="checked">Continue with self-signed</label>
+      <label for="radio-selfsigned-false"><input id="radio-selfsigned-false" type="radio" name="selfsigned" value="0">Upload SSL certificate</label>
+    </fieldset>
+    <fieldset id="ssl">
+      <div>
+        <label for="file-publickey" class="required">Public key</label>
+        <input type="file" name="file-publickey" id="file-publickey" />
+      </div>
+      <div>
+        <label for="file-privatekey" class="required">Private key</label>
+        <input type="file" name="file-privatekey" id="file-privatekey" />
+      </div>
+    </fieldset>
 
   </div>
   <div class="page" id="page-accounts">
@@ -34,7 +34,7 @@
     <fieldset>
       <label for="text-password-1" class="required">Password</label>
       <input type="password" id="text-password-1" name="password-1" />
-      <p class="hint">8–20 alphanumeric characters, at least one digit and one letter is required.</p>
+      <p class="hint">8+ alphanumeric characters, at least one digit and one letter is required.</p>
       <label for="text-password-2" class="required">Confirm</label>
       <input type="password" id="text-password-2" name="password-2" />
     </fieldset>
@@ -43,9 +43,21 @@
     <fieldset>
       <label for="text-username" class="required">Username</label>
       <input type="text" id="text-username" name="username" value="stanley" />
-      <label for="textarea-integrationacct">SSH key</label>
-      <textarea name="integrationacct" id="textarea-integrationacct" cols="30" rows="10"></textarea>
     </fieldset>
+    <fieldset id="ssh-enable">
+        <label for="radio-sshgen-true"><input id="radio-sshgen-true" type="radio" name="sshgen" value="1" checked="checked">Generate a new SSH key pair for the account</label>
+        <label for="radio-sshgen-false"><input id="radio-sshgen-false" type="radio" name="sshgen" value="0">Use an existing key pair</label>
+      </fieldset>
+      <fieldset id="ssh">
+        <div>
+          <label for="file-ssh-publickey" class="required">Public key</label>
+          <input type="file" name="file-ssh-publickey" id="file-ssh-publickey" />
+        </div>
+        <div>
+          <label for="file-ssh-privatekey" class="required">Private key</label>
+          <input type="file" name="file-ssh-privatekey" id="file-ssh-privatekey" />
+        </div>
+      </fieldset>
   </div>
   <div class="page" id="page-chatops">
     <h1>Configure ChatOps</h1>
@@ -118,4 +130,6 @@
     <a href="#" id="step-back">Back</a>
     <p>Step <span id="current-step"></span> of <span id="total-steps"></span></p>
   </div>
+  <input type="hidden" name="comparison" id="hidden-comparison" value=""/>
 </form>
+<iframe style="display:none" id="keypair-frame" name="keypair-frame"></iframe>

--- a/st2installer/templates/progress.html
+++ b/st2installer/templates/progress.html
@@ -5,9 +5,6 @@
 <div class="page" id="page-puppet">
   <h1>Installation</h1>
   <p>StackStorm is preparing for the first launch! Installation will take a few more minutes.</p>
-  % if keyfallback == 'fallback':
-    <p>SSH keys are not valid, reverting to a self-signed certificate.</p>
-  % endif
   <div id="warning-count">
     <span id="warnings">0</span> warning<span id="warnings-plural">s</span>, <span id="errors">0</span> error<span id="errors-plural">s</span>.
     <div id="filtering">


### PR DESCRIPTION
1. Uploaded SSL key pair (step 1) and SSH key pair (step 2) both get "real" validation through ssh-keygen with a modal window asking the user to resort to generated keys.
2. SSH key pair can be generated with python's RSA module. The user is prompted to save the keys with a modal window.