### PR TITLE
Add `ST2_API` and `ST2_AUTH_URL` to answers file.

### DIFF
--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -74,7 +74,10 @@ class RootController(object):
       "hubot::env_export": {
         "HUBOT_LOG_LEVEL":   "debug",
         "ST2_AUTH_USERNAME": "chatops_bot",
-        "ST2_AUTH_PASSWORD": password
+        "ST2_AUTH_PASSWORD": password,
+        "ST2_API": "https://%s:9101" % kwargs['hostname'],
+        "ST2_WEBUI_URL": "https://%s" % kwargs['hostname'],
+        "ST2_AUTH_URL": "https://%s:9100" % kwargs['hostname']
       },
       "hubot::external_scripts": ["hubot-stackstorm"],
       "hubot::dependencies": {


### PR DESCRIPTION
This commit adds three variables, `ST2_API`, `ST2_AUTH_URL`, and `ST2_WEBUI_URL` to the auto-generated answers file. This is needed to authenticate hubot.