### PR TITLE
needs to check for key in dict for anon-data upload

### DIFF
--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -78,7 +78,7 @@ class RootController(object):
     self.hostname = kwargs['hostname']
 
     password = kwargs['hubot-password']
-    collect_anonymous_data = True if kwargs["anon-data"] else False
+    collect_anonymous_data = True if 'anon-data' in kwargs else False
     uuid = str(uuid1())
 
     config = {


### PR DESCRIPTION
Need to check for existence of key in the dict, otherwise bombs out with 

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/pecan/middleware/debug.py", line 289, in __call__
    return self.app(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/pecan/middleware/recursive.py", line 56, in __call__
    return self.application(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/pecan/middleware/errordocument.py", line 75, in __call__
    app_iter = self.app(environ, replacement_start_response)
  File "/usr/local/lib/python2.7/dist-packages/pecan/core.py", line 762, in __call__
    return super(Pecan, self).__call__(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/pecan/core.py", line 625, in __call__
    self.invoke_controller(controller, args, kwargs, state)
  File "/usr/local/lib/python2.7/dist-packages/pecan/core.py", line 531, in invoke_controller
    result = controller(*args, **kwargs)
  File "./st2installer/controllers/root.py", line 81, in index_post
    collect_anonymous_data = True if kwargs["anon-data"] else False
KeyError: 'anon-data'
```