### PR TITLE
Make admin account configurable

### DIFF
--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -95,7 +95,7 @@ class RootController(object):
       "st2::cli_auth_url":              "https://%s:9100" % kwargs['hostname'],
       "st2::stanley::username":         kwargs['username'],
       "users": {
-        "admin": {
+        kwargs['admin-username']: {
           "password": kwargs['password-1'],
           "admin": True,
         },

--- a/st2installer/templates/index.html
+++ b/st2installer/templates/index.html
@@ -3,12 +3,13 @@
 <form id="installer" method="POST" action="." enctype="multipart/form-data">
   <div class="page" id="page-hostname">
     <h1>Configure Hostname and SSL</h1>
-
-    <input type="hidden" name="hubot-password" id="hubot-password" value="${hubotpassword}" />
-
-    <label for="text-hostname" class="required">Hostname</label>
-    <input type="text" id="text-hostname" name="hostname" />
-    <p class="hint">FQDN of host.</p>
+    <p>Please enter the hostname you would like this server to be called below. Ensure this hostname is reachable via DNS</p>
+    <fieldset>
+      <label for="text-hostname" class="required">Hostname</label>
+      <input type="hidden" name="hubot-password" id="hubot-password" value="${hubotpassword}" />
+      <input type="text" id="text-hostname" name="hostname" />
+      <p class="hint">FQDN of host.</p>
+    </fieldset>
 
     <label for="check-anon-data"><input id="check-anon-data" type="checkbox" name="anon-data" value="1" checked="checked">Allow sending anonymous usage reports</label>
     <p class="hint">Sending usage data from your instance will help StackStorm grow into a better product. All reports are fully anonymous and conform to our strict <a href="http://stackstorm.com/privacy-policy/" target="_blank">privacy policy</a>.</p>

--- a/st2installer/templates/index.html
+++ b/st2installer/templates/index.html
@@ -34,8 +34,10 @@
   <div class="page" id="page-accounts">
     <h1>Setup user accounts</h1>
     <h2>Setup admin account</h2>
-    <p>This installer will create a new user, admin, to be used as the Administrator account. This account will be used to remotely log in via SSH, and to log in via the WebUI. Enter a password below for this account.</p>
+    <p>This installer will your first user account to be used as the Administrator account for StackStorm. This account can be used to remotely log into the StackStorm server via SSH, and to view the StackStorm WebUI. Enter a username and password below for this account.</p>
     <fieldset>
+      <label for="text-admin-username" class="required">Username</label>
+      <input type="text" id="text-admin-username" name="admin-username" value="admin" />
       <label for="text-password-1" class="required">Password</label>
       <input type="password" id="text-password-1" name="password-1" />
       <p class="hint">8+ alphanumeric characters, at least one digit and one letter is required.</p>


### PR DESCRIPTION
This PR makes the freshly created admin account a configurable value at boot to reduce confusion for new users.