### PR TITLE
Show RootCA warning if a CA is generated and accessible

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -40,15 +40,15 @@ var i18n = {
   }
 };
 var puppet = {
-  warning: [ 
+  warning: [
     /warn/i
   ],
-  error: [ 
+  error: [
     /error/i,
     /fail/i
   ],
   important: [
-    
+
   ],
   checkpoints: [
     [/apply hostname.*executed successfully/, 15],
@@ -94,8 +94,8 @@ var puppet = {
   },
   read: function() {
     var stream = $.ajax({
-      url: puppet.url, 
-      data: {line: puppet.line}, 
+      url: puppet.url,
+      data: {line: puppet.line},
       timeout: 500,
       complete: function(data, status) {
         data = String(data.responseText);
@@ -151,8 +151,15 @@ var puppet = {
   },
   complete: function() {
     $('#page-puppet').removeClass('progress');
-    $('#puppet-done').show(); 
+    $('#puppet-done').show();
     $.get(puppet.cleanup);
+    $.ajax({
+      type: 'HEAD',
+      url: '/ssl/st2_root_ca.cer',
+      success: function() {
+        $('#rootca-warning').show();
+      }
+    });
   },
   init: function() {
     $('#page-puppet').addClass('progress');
@@ -172,7 +179,7 @@ var puppet = {
 
 }
 var installer = {
-  page: 0, 
+  page: 0,
   chatops: 0,
   errors: 0,
   key_validator: 'keypair/',
@@ -245,7 +252,7 @@ var installer = {
     '</div>'
   ),
   raise_modal: function(template) {
-    
+
     $('#modal-overflow').remove();
     modal = installer.modal;
     modal.find('h3').text(i18n[template].header);
@@ -293,7 +300,7 @@ var installer = {
         installer.append_error(hostname, i18n.fqdn);
       }
 
-      if ($('#radio-selfsigned-false').is(':checked') && 
+      if ($('#radio-selfsigned-false').is(':checked') &&
           ($('#file-publickey').val().trim().length==0 ||
            $('#file-privatekey').val().trim().length==0)) {
         installer.append_error($('#ssl'), i18n.ssl_required);
@@ -329,10 +336,10 @@ var installer = {
         installer.append_error(username, i18n.required);
       }
 
-      if ($('#radio-sshgen-false').is(':checked') && 
+      if ($('#radio-sshgen-false').is(':checked') &&
           ($('#file-ssh-publickey').val().trim().length==0 ||
            $('#file-ssh-privatekey').val().trim().length==0)) {
-        installer.append_error($('#ssh'), i18n.ssl_required);  
+        installer.append_error($('#ssh'), i18n.ssl_required);
       }
 
       if ($('#radio-sshgen-false').is(':checked') &&
@@ -399,7 +406,7 @@ var installer = {
           }
         });
       } else if (installer.page == 1 &&
-                 $('#radio-sshgen-true').is(':checked') && 
+                 $('#radio-sshgen-true').is(':checked') &&
                  $('#gen-private').val() == '') {
         $.get(installer.key_generator).always(function(keypair) {
           $('#gen-private').val(keypair.private);

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -68,7 +68,7 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: 200;
   color: #f4f4f4;
 }
-#header {  
+#header {
   border-top: 5px solid #ff8300;
   background: #000000 url(../images/logo.png) no-repeat 20px 20px;
   height: 70px;
@@ -465,13 +465,13 @@ label.required:after {
   position: absolute;
   top: 0; left: 0; bottom: 0; right: 0;
   background-image: linear-gradient(
-    -45deg, 
-    rgba(255, 255, 255, .1) 25%, 
-    transparent 25%, 
-    transparent 50%, 
-    rgba(255, 255, 255, .1) 50%, 
-    rgba(255, 255, 255, .1) 75%, 
-    transparent 75%, 
+    -45deg,
+    rgba(255, 255, 255, .1) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, .1) 50%,
+    rgba(255, 255, 255, .1) 75%,
+    transparent 75%,
     transparent
   );
   z-index: 1;
@@ -607,4 +607,35 @@ label[for="check-chatops"] {
 }
 #modal-buttons {
   clear: both;
+}
+
+#rootca-warning {
+  display: none;
+  background-color: #252525;
+  padding: 15px 20px;
+  border-radius: 5px;
+  margin-bottom: 20px;
+  clear: both;
+  position: relative;
+  margin-top: 40px;
+  padding-bottom: 15px;
+}
+#rootca-warning h4 {
+  color: white;
+  font-weight: normal;
+  margin-bottom: 10px;
+  margin-top: 5px;
+}
+#rootca-warning ul {
+  margin-top: 5px;
+  margin-bottom: 20px;
+}
+#rootca-warning i {
+  color: white;
+  font-size: 20px;
+  margin-right: 5px;
+}
+#rootca-warning p {
+  padding: 0;
+  margin: 0;
 }

--- a/st2installer/templates/layout.html
+++ b/st2installer/templates/layout.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="stylesheets/reset.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,300">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Oswald:400,300">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="stylesheets/main.css">
   </head>
   <body>
@@ -19,7 +20,7 @@
         </ul>
       </%block>
     </div>
-    
+
     ${self.body()}
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>

--- a/st2installer/templates/progress.html
+++ b/st2installer/templates/progress.html
@@ -18,7 +18,7 @@
   </div>
   <div id="output">
     <div id="output-content">
-      
+
     </div>
   </div>
   <div id="puppet-done">
@@ -29,6 +29,17 @@
       <li><a href="https://www.youtube.com/channel/UCColc5CuBJ8-1SnALnkDz8Q" target="_blank">YouTube channel</a></li>
       <li><a href="http://stackstorm.com/blog" target="_blank">Blog</a></li>
     </ul>
+
+    <div id="rootca-warning">
+      <h4><i class="fa fa-exclamation-triangle"></i> StackStorm Root CA</h4>
+      <p>Because you're using a self-signed SSL certificate, you need to install StackStorm Root CA in order for UI and API to communicate:</p>
+      <ul>
+        <li><a href="/ssl/st2_root_ca.cer" target="_blank">Download your Root CA</a></li>
+        <li><a href="http://wiki.cacert.org/FAQ/ImportRootCert" target="_blank">Read the installation manual on CAcert wiki</a></li>
+      </ul>
+      <p>Safety notice: this CA was automatically generated on your server, it's not shared across different StackStorm installations nor is it accessible by anyone but you. Never share it with anyone except users of your StackStorm instance.</p>
+    </div>
+
     <div id="next-button">
       <a href="https://${hostname}" id="step-next">Open StackStorm</a>
     </div>


### PR DESCRIPTION
Fixes #29

If a root CA is present (we’re checking `/ssl/st2_root_ca.cer` with a HEAD request), display a warning about installing it with a link to wiki and the certificate itself.