### PR TITLE
Use config_written instead of is_locked

### DIFF
--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -249,7 +249,7 @@ class RootController(object):
 
   @expose(generic=True, template='progress.html')
   def install(self):
-    if self.is_locked():
+    if self.config_written:
       return {"hostname": self.hostname}
     else:
       redirect('/', internal=True)


### PR DESCRIPTION
* is_locked is useful only after lock is called. Lock
  is not called until much later and reverting back to
  config_written is better. This may not actually be the
  right fix but it does unblock the DOA build.