### PR TITLE
Replace "." and ":" with hyphen incase provided value is an IP

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ singledispatch==3.4.0.3
 six==1.9.0
 waitress==0.8.9
 wsgiref==0.1.2
+IPy==0.83


### PR DESCRIPTION
* Using IP  instead of hostname causes much pain an misery so replacing
  . and : with hyphen.