### PR TITLE
Update puppet-check with full pgrep flag

### DIFF
--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -21,7 +21,7 @@ class RootController(object):
         self.configname = "answers.json"
         self.hostname = ''
         self.config_written = False
-        self.puppet_check = 'pgrep puprun'
+        self.puppet_check = 'pgrep -f puppet-apply'
 
         config = config or conf.to_dict()
         if 'puppet' in config and 'command' in config['puppet']:


### PR DESCRIPTION
This commit updates the `pgrep` check to look for the actual process called (`puppet-apply`), and parsing the entire procline.