### PR TITLE
[WIP] Analytics

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -103,8 +103,20 @@ var puppet = {
           lines = data.split('\n');
           for (var i = 0; i < lines.length; i++) {
             line = lines[i];
-            if (i == lines.length-1 && line == '--terminate--') {
+            if (i == lines.length-1 && line.slice(0, 13) == '--terminate--') {
               puppet.set_progress(100);
+              runtime = parseInt(line.slice(13));
+              if (ga && runtime) {
+                var metrics = {
+                  'metric2': parseInt($('#errors').text()),
+                  'metric3': parseInt($('#warnings').text()),
+                  'dimension1': $('#ga-chatops').val(),
+                  'dimension2': $('#ga-ssh').val(),
+                  'dimention2': $('#ga-ssl').val(),
+                };
+                ga('send', 'event', 'installer', 'complete', metrics);
+                ga('send', 'timing', 'Puppet', 'runtime', runtime);
+              }
             } else if (line.trim()) {
               puppet.line += 1;
               p_class = 'message';
@@ -208,6 +220,9 @@ var installer = {
         $('#step-back').hide();
       } else {
         $('#step-back').show();
+      }
+      if (ga) {
+        ga('send', 'pageview', '/step'+page);
       }
     };
     if (page <= installer.page) {

--- a/st2installer/templates/layout.html
+++ b/st2installer/templates/layout.html
@@ -8,6 +8,15 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Oswald:400,300">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="stylesheets/main.css">
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-46030182-3', {'cookieDomain': 'none'});
+      ga('send', 'pageview');
+    </script>
   </head>
   <body>
     <div id="header">

--- a/st2installer/templates/progress.html
+++ b/st2installer/templates/progress.html
@@ -2,6 +2,10 @@
 
 <%block name="stepcount"/>
 
+<input type="hidden" id="ga-chatops" name="ga-chatops" value="${chatops}" />
+<input type="hidden" id="ga-ssh" name="ga-ssh" value="${gen_ssh}" />
+<input type="hidden" id="ga-ssl" name="ga-ssl" value="${gen_ssl}" />
+
 <div class="page" id="page-puppet">
   <h1>Installation</h1>
   <p>StackStorm is preparing for the first launch! Installation will take a few more minutes.</p>


### PR DESCRIPTION
Google Analytics wiring:
1. Basic page tracking (regarding tabs as separate pages so we can track how much time does it take to complete each)
2. Puppet runtime tracking
3. Chatops back-end: enabled/disabled, backend
4. SSH/SSL tracking: generated/uploaded, self-signed/uploaded

I created all the necessary metrics and dimensions inside the StackStorm GA account as well. 

Note: right now the data doesn’t show up in GA, __don’t merge__ until I figure out what’s going on. Browser is able to send requests, I can see the beacons, I checked that the right data gets sent, but nothing shows up in Google Analytics panel.

Probably it’s connected to the fact we’re running Installer in intranet without a permanent domain, but I do know that it’s possible. Some people warn that for intranet data to appear we should wait at least 24 hours, so let’s do that, but if it doesn’t fix things, I’ll need help.