### PR TITLE
Generate SSH key pair on demand, download it using JavaScript

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -256,10 +256,10 @@ var installer = {
         '<div id="keypair">' +
           '<label for="keypair-public">Your public key</label>' +
           '<textarea id="keypair-public"></textarea>' +
-          '<a id="download-public-key">Download</a>' +
+          '<a data-key-type="public" data-key-filename="st2-ssh.pub" class="download-ssh-key">Download</a>' +
           '<label for="keypair-private">Your private key</label>' +
           '<textarea id="keypair-private"></textarea>' +
-          '<a id="download-private-key">Download</a>' +
+          '<a data-key-type="private" data-key-filename="st2-ssh.key" class="download-ssh-key">Download</a>' +
         '</div>' +
         '<div id="modal-buttons">' +
         '</div>' +
@@ -505,20 +505,15 @@ $(function() {
     puppet.init();
   }
 
-  $(document).on('click', 'a#download-public-key', function() {
-    var filename, data;
-    filename = 'st2-ssh.pub';
-    data = $('#keypair-public').val();
-    elem = download_as_file(filename, data);
-    $('body').append(elem);
-    elem.click();
-  });
+  $(document).on('click', '.download-ssh-key', function(e) {
+    var key_type, key_filename, data;
 
-  $(document).on('click', 'a#download-private-key', function() {
-    var filename, data;
-    filename = 'st2-ssh.key';
-    data = $('#keypair-private').val();
-    elem = download_as_file(filename, data);
+    key_type = $(this).attr('data-key-type');
+    key_filename = $(this).attr('data-key-filename');
+
+    id = $(this).attr('id');
+    data = $('#keypair-' + key_type).val();
+    elem = download_as_file(key_filename, data);
     $('body').append(elem);
     elem.click();
   });

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -256,10 +256,10 @@ var installer = {
         '<div id="keypair">' +
           '<label for="keypair-public">Your public key</label>' +
           '<textarea id="keypair-public"></textarea>' +
-          '<a href="keypair/public">Download</a>' +
+          '<a id="download-public-key">Download</a>' +
           '<label for="keypair-private">Your private key</label>' +
           '<textarea id="keypair-private"></textarea>' +
-          '<a href="keypair/private">Download</a>' +
+          '<a id="download-private-key">Download</a>' +
         '</div>' +
         '<div id="modal-buttons">' +
         '</div>' +
@@ -503,5 +503,34 @@ $(function() {
   }
   if ($('#page-puppet').length) {
     puppet.init();
+  }
+
+  $(document).on('click', 'a#download-public-key', function() {
+    var filename, data;
+    filename = 'st2-ssh.pub';
+    data = $('#keypair-public').val();
+    elem = download_as_file(filename, data);
+    $('body').append(elem);
+    elem.click();
+  });
+
+  $(document).on('click', 'a#download-private-key', function() {
+    var filename, data;
+    filename = 'st2-ssh.key';
+    data = $('#keypair-private').val();
+    elem = download_as_file(filename, data);
+    $('body').append(elem);
+    elem.click();
+  });
+
+  function download_as_file(filename, data) {
+    var elem, encoded_data;
+
+    encoded_data = window.btoa(unescape(encodeURIComponent(data)));
+    elem = document.createElement('a');
+    elem.download = filename;
+    elem.textContent = filename;
+    elem.href = 'data:application/octet-stream;base64,' + encoded_data;
+    return elem;
   }
 });

--- a/st2installer/controllers/keypair.py
+++ b/st2installer/controllers/keypair.py
@@ -28,9 +28,6 @@ class KeypairController(BaseController):
         self.ssh_diff = os.path.join(ROOT_DIR, 'keycompare')
         self.ssl_diff = os.path.join(ROOT_DIR, 'sslcompare')
 
-        self.gen_private = RSA.generate(DEFAULT_RSA_KEY_SIZE, os.urandom)
-        self.gen_public = self.gen_private.publickey()
-
     def compare(self, diff, private, public):
         with open(self.privatefile, 'w') as temp_private:
             temp_private.write(private)
@@ -73,17 +70,10 @@ class KeypairController(BaseController):
 
     @expose('json')
     def keygen(self):
+        private_key = RSA.generate(DEFAULT_RSA_KEY_SIZE, os.urandom)
+        public_key = private_key.publickey()
+
         return {
-            'private': self.gen_private.exportKey('PEM'),
-            'public': self.gen_public.exportKey('OpenSSH')[8:]
+            'private': private_key.exportKey('PEM'),
+            'public': public_key.exportKey('OpenSSH')[8:]
         }
-
-    @expose(content_type='application/octet-stream')
-    def private(self):
-        response.headers['Content-Disposition'] = 'attachment; filename="st2-ssh.key"'
-        return self.gen_private.exportKey('PEM')
-
-    @expose(content_type='application/octet-stream')
-    def public(self):
-        response.headers['Content-Disposition'] = 'attachment; filename="st2-ssh.pub"'
-        return self.gen_public.exportKey('OpenSSH')

--- a/st2installer/tests/test_functional.py
+++ b/st2installer/tests/test_functional.py
@@ -106,18 +106,6 @@ class FunctionalTest(BaseTestCase):
         self.assertTrue(self.public_regex.match('ssh-rsa '+body['public']))
         self.assertTrue(self.private_regex.match(body['private']))
 
-    def test_keypair_private(self):
-        response = self.app.get('/keypair/private')
-        self.assertEqual(response.status_int, 200)
-        self.assertEqual(response.content_disposition, 'attachment; filename="st2-ssh.key"')
-        self.assertTrue(self.private_regex.match(response.body))
-
-    def test_keypair_public(self):
-        response = self.app.get('/keypair/public')
-        self.assertEqual(response.status_int, 200)
-        self.assertEqual(response.content_disposition, 'attachment; filename="st2-ssh.pub"')
-        self.assertTrue(self.public_regex.match(response.body))
-
     def test_root_datasave(self):
         response = self.app.get('/data_save', params={'hostname': 'new-hostname-test', 'password': 'new-password-test'})
         self.assertEqual(response.status_int, 204)

--- a/st2installer/tests/test_functional.py
+++ b/st2installer/tests/test_functional.py
@@ -106,6 +106,19 @@ class FunctionalTest(BaseTestCase):
         self.assertTrue(self.public_regex.match('ssh-rsa '+body['public']))
         self.assertTrue(self.private_regex.match(body['private']))
 
+    def test_keypair_gen_key_pair_is_generated_on_demand(self):
+        # Make sure new key pair is generated for each request
+        seen_private_keys = []
+        for index in range(0, 3):
+            response = self.app.get('/keypair/keygen')
+            body = response.json
+            self.assertEqual(response.status_int, 200)
+            self.assertTrue(self.public_regex.match('ssh-rsa '+body['public']))
+            self.assertTrue(self.private_regex.match(body['private']))
+
+            self.assertTrue(body['private'] not in seen_private_keys)
+            seen_private_keys.append(body['private'])
+
     def test_root_datasave(self):
         response = self.app.get('/data_save', params={'hostname': 'new-hostname-test', 'password': 'new-password-test'})
         self.assertEqual(response.status_int, 204)

--- a/st2installer/tests/test_functional.py
+++ b/st2installer/tests/test_functional.py
@@ -118,6 +118,7 @@ class FunctionalTest(BaseTestCase):
 
             self.assertTrue(body['private'] not in seen_private_keys)
             seen_private_keys.append(body['private'])
+        self.assertEqual(len(seen_private_keys), 3)
 
     def test_root_datasave(self):
         response = self.app.get('/data_save', params={'hostname': 'new-hostname-test', 'password': 'new-password-test'})


### PR DESCRIPTION
This pull request updates KeyPair controller to create SSH key pair on demand instead of generating it inside the constructor and leaving it hanging in the memory...

In addition to that, it implements "download key as file" functionality on the client side so we don't need to leave key hanging in memory. If we want to use old approach, but do it more securely we would need to implement some kind of session mechanism, but this is a big over kill since we can just handle it with JavaScript (all modern browsers support this functionality).
