### PR TITLE
Enterprise modifications

### DIFF
--- a/config.py
+++ b/config.py
@@ -31,14 +31,14 @@ logging = {
             'format': ('%(asctime)s %(levelname)-5.5s [%(name)s]'
                        '[%(threadName)s] %(message)s')
         },
-	'messageonly': {
-	    'format': '%(message)s'
-	},
+        'messageonly': {
+            'format': '%(message)s'
+        },
         'color': {
             '()': 'pecan.log.ColorFormatter',
             'format': ('%(asctime)s [%(padded_color_levelname)s] [%(name)s]'
                        '[%(threadName)s] %(message)s'),
-        '__force_dict__': True
+            '__force_dict__': True
         }
     }
 }

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -14,8 +14,8 @@ var i18n = {
   flowdock: "All fields are required for Flowdock integration.",
   ssh: {
     'header': "Whoa. The keys do not match!",
-    'text': "It appears you've uploaded a key pair that either does not match, is password protected or isn't really a key pair at all! \
-              You can upload another set of keys or we can just generate a new key pair for you, no problem.",
+    'text': "It appears you've uploaded a key pair that either does not match, is password protected or isn't really a key pair at all! " +
+            "You can upload another set of keys or we can just generate a new key pair for you, no problem.",
     'buttons': [
       ['Generate', '#generate'],
       ['Re-upload', '#back']
@@ -23,9 +23,9 @@ var i18n = {
   },
   ssl: {
     'header': "Certificate error",
-    'text': "It appears you've uploaded a certificate and a private key that either do not match or aren't in the right format! \
-              You need to upload a PEM certificate and a private key without a passphrase. \
-              You can upload another certificate or we can just generate a self-signed one for you, no problem.",
+    'text': "It appears you've uploaded a certificate and a private key that either do not match or aren't in the right format! " +
+              "You need to upload a PEM certificate and a private key without a passphrase. " +
+              "You can upload another certificate or we can just generate a self-signed one for you, no problem.",
     'buttons': [
       ['Generate', '#generate'],
       ['Re-upload', '#back']
@@ -121,24 +121,25 @@ var puppet = {
               puppet.line += 1;
               p_class = 'message';
 
-              for (var ii = 0; ii < puppet.important.length; ii++) {
+              var ii;
+              for (ii = 0; ii < puppet.important.length; ii++) {
                 if (puppet.important[ii].test(line)) {
                   p_class = 'output-important';
                 }
               }
-              for (var ii = 0; ii < puppet.warning.length; ii++) {
+              for (ii = 0; ii < puppet.warning.length; ii++) {
                 if (puppet.warning[ii].test(line)) {
                   p_class = 'output-warning';
                   puppet.add_warning();
                 }
               }
-              for (var ii = 0; ii < puppet.error.length; ii++) {
+              for (ii = 0; ii < puppet.error.length; ii++) {
                 if (puppet.error[ii].test(line)) {
                   p_class = 'output-error';
                   puppet.add_error();
                 }
               }
-              for (var ii = 0; ii < puppet.checkpoints.length; ii++) {
+              for (ii = 0; ii < puppet.checkpoints.length; ii++) {
                 if (puppet.checkpoints[ii][0].test(line)) {
                   p_class = 'output-important';
                   puppet.set_progress(puppet.checkpoints[ii][1]);
@@ -162,7 +163,9 @@ var puppet = {
     });
   },
   complete: function() {
-    $('#page-puppet').removeClass('progress');
+    $('#page-puppet')
+      .removeClass('progress')
+      .addClass('done');
     $('#puppet-done').show();
     $.get(puppet.cleanup);
     $.ajax({

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -382,7 +382,7 @@ label.required:after {
   border-radius: 0 0 5px 5px;
   height: 300px;
   overflow-x: auto;
-  overflow-y: scroll;
+  overflow-y: auto;
   margin-bottom: 30px;
   background: #252525;
   padding: 10px;
@@ -496,12 +496,12 @@ label.required:after {
 #puppet-done ul {
   margin-left: 20px;
 }
-#puppet-done #next-button,
+#page-puppet #next-button,
 #page-static #next-button {
   text-align: center;
   margin-bottom: 20px;
 }
-#puppet-done #next-button a,
+#page-puppet #next-button a,
 #page-static #next-button a {
   float: none;
   margin: 0 auto;
@@ -614,10 +614,10 @@ label[for="check-chatops"] {
   background-color: #252525;
   padding: 15px 20px;
   border-radius: 5px;
-  margin-bottom: 20px;
+  margin-bottom: 30px;
   clear: both;
   position: relative;
-  margin-top: 40px;
+  margin-top: 30px;
   padding-bottom: 15px;
 }
 #rootca-warning h4 {
@@ -629,6 +629,7 @@ label[for="check-chatops"] {
 #rootca-warning ul {
   margin-top: 5px;
   margin-bottom: 20px;
+  margin-left: 20px;
 }
 #rootca-warning i {
   color: white;
@@ -638,4 +639,78 @@ label[for="check-chatops"] {
 #rootca-warning p {
   padding: 0;
   margin: 0;
+}
+
+
+label[for="check-enterprise"] {
+  margin-top: 15px;
+  margin-bottom: 10px;
+}
+
+.page.progress .done {
+  display: none;
+}
+.page.done .progress {
+  display: none;
+}
+.page.done .done {
+  display: block;
+}
+.page.progress .progress {
+  display: block;
+}
+p.signature {
+  padding: 20px;
+  margin-bottom: 40px;
+}
+p.signature em {
+  display: block;
+  text-align: right;
+  margin-right: 10px;
+}
+
+#page-puppet #next-button {
+  margin-bottom: 25px;
+}
+
+#puppet-done {
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+  text-align: center;
+  margin-bottom: 20px;
+}
+#puppet-done ul {
+  margin: 0;
+}
+#puppet-done li {
+  display: inline-block;
+  list-style: none;
+  margin: 0 10px;
+  vertical-align: top;
+}
+#puppet-done li a {
+  margin-top: 2px;
+  height: 42px;
+  text-decoration: none;
+  line-height: 24px;
+  display: block;
+  padding: 7px 15px 5px;
+  box-sizing: border-box;
+  background: #252525;
+  border-radius: 5px;
+  border: 1px solid #994F00;
+  border-bottom: 2px solid #ff8300;
+  border-right: 2px solid #ff8300;
+}
+#puppet-done li a:hover {
+  background: #333;
+}
+#puppet-done li i {
+  font-size: 24px;
+  vertical-align: top;
+  margin-right: 5px;
+}
+#warning-count {
+  margin-top: 30px;
 }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -714,3 +714,18 @@ p.signature em {
 #warning-count {
   margin-top: 30px;
 }
+
+.enter-pi {
+  margin-top: 15px;
+}
+
+input[type=text]:disabled {
+  background-image: linear-gradient(
+    to right top,
+    transparent 33%,
+    black 33%,
+    black 66%,
+    transparent 66%
+  );
+  background-size: 3px 3px;
+}

--- a/st2installer/controllers/keypair.py
+++ b/st2installer/controllers/keypair.py
@@ -1,13 +1,8 @@
 import tempfile
 import subprocess
-import six
-from six.moves import shlex_quote
-from six.moves.urllib import parse as urlparse
-from pecan import expose, request, response, redirect, abort
-import random, string, os
-from pecan import expose, request, response, abort
-from Crypto.PublicKey import RSA
 import os
+from pecan import expose, request, abort
+from Crypto.PublicKey import RSA
 from st2installer.controllers.base import BaseController
 
 

--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -209,7 +209,7 @@ class RootController(BaseController):
             config["st2::stanley::ssh_private_key"] = kwargs['gen-private']
             config["st2::stanley::ssh_public_key"] = kwargs['gen-public']
 
-        if kwargs["enterprise"] != "":
+        if "enterprise" in kwargs and kwargs["enterprise"] != "":
             config["st2enterprise::token"] = kwargs["enterprise"]
 
         if "check-chatops" in kwargs and kwargs["check-chatops"] == "1":

--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -34,7 +34,10 @@ class RootController(BaseController):
         if 'puppet' in config and 'command' in config['puppet']:
             self.command = config['puppet']['command']
         else:
-            self.command = '/usr/bin/sudo FACTER_installer_running=true ENV=current_working_directory NOCOLOR=true /usr/bin/puprun'
+            self.command = '/usr/bin/sudo ' + \
+                           'FACTER_installer_running=true ' + \
+                           'ENV=current_working_directory ' + \
+                           'NOCOLOR=true /usr/bin/puprun'
         if 'puppet' in config and 'hieradata' in config['puppet']:
             self.path = config['puppet']['hieradata']
         else:
@@ -45,7 +48,8 @@ class RootController(BaseController):
         self.password = ''.join([random.choice(password_chars) for n in xrange(password_length)])
 
         # Note, any command added here needs to be added to the workroom sudoers entry.
-        # File can be found at https://github.com/StackStorm/st2workroom/blob/master/modules/profile/manifests/st2server.pp#L513
+        # File can be found at
+        # https://github.com/StackStorm/st2workroom/blob/master/modules/profile/manifests/st2server.pp#L513
         self.cleanup_chain = [
             "/usr/bin/sudo /bin/chmod 660 %s%s" % (self.path, self.configname),
             "/usr/bin/sudo /usr/sbin/service nginx restart",
@@ -72,6 +76,10 @@ class RootController(BaseController):
         elif self.puppet_check():
             redirect('/wait', internal=True)
 
+    def get_enterprise_token(self):
+        # Hardcoded for now
+        return "token"
+
     @expose(content_type='text/plain')
     def cleanup(self):
         for command in self.cleanup_chain:
@@ -91,13 +99,13 @@ class RootController(BaseController):
         logfile = open(self.output, 'r')
         for i, logline in enumerate(logfile):
             if i >= int(line):
-                data += logline.strip()+'\n'
+                data += logline.strip() + '\n'
         logfile.close()
 
         if self.proc.poll() is not None:
             data += '--terminate--'
             if not self.runtime:
-                self.runtime = (time.time() - self.start_time)*1000
+                self.runtime = (time.time() - self.start_time) * 1000
                 data += str(self.runtime)
         if not data:
             return '--idle--'
@@ -146,24 +154,25 @@ class RootController(BaseController):
             pass
 
         self.hostname = kwargs['hostname']
-
         password = kwargs['hubot-password']
 
-        if "anon-data" in kwargs:
-                collect_anonymous_data = True
-        else:
-                collect_anonymous_data = False
+        collect_anonymous_data = True if "anon-data" in kwargs else False
+        token = self.get_enterprise_token if "enterprise" in kwargs else ""
 
         uuid = str(uuid1())
 
         config = {
-            "system::hostname":       system_hostname,
-            "st2::installer_run":     True,
-            "st2::api_url":           "https://%s:9101" % kwargs['hostname'],
-            "st2::auth_url":          "https://%s:9100" % kwargs['hostname'],
-            "st2::cli_api_url":       "https://%s:9101" % kwargs['hostname'],
-            "st2::cli_auth_url":      "https://%s:9100" % kwargs['hostname'],
+            "system::hostname": system_hostname,
+            "st2::installer_run": True,
+
+            "st2::api_url": "https://%s:9101" % kwargs['hostname'],
+            "st2::auth_url": "https://%s:9100" % kwargs['hostname'],
+
+            "st2::cli_api_url": "https://%s:9101" % kwargs['hostname'],
+            "st2::cli_auth_url": "https://%s:9100" % kwargs['hostname'],
+
             "st2::stanley::username": kwargs['username'],
+            "st2enterprise::token": token,
             "users": {
                 kwargs['admin-username']: {
                     "password": kwargs['password-1'],
@@ -210,7 +219,7 @@ class RootController(BaseController):
             config.update({
                 "hubot::chat_alias": "!",
                 "hubot::env_export": {
-                    "HUBOT_LOG_LEVEL":   "debug",
+                    "HUBOT_LOG_LEVEL": "debug",
                     "ST2_AUTH_USERNAME": "chatops_bot",
                     "ST2_AUTH_PASSWORD": password,
                     "ST2_API": "https://%s:9101" % kwargs['hostname'],
@@ -230,17 +239,17 @@ class RootController(BaseController):
             if kwargs["chatops"] == "example":
                 config["hubot::adapter"] = "irc"
                 config["hubot::env_export"].update({
-                    "HUBOT_IRC_SERVER":   "localhost",
-                    "HUBOT_IRC_ROOMS":    "#stackstorm",
-                    "HUBOT_IRC_NICK":     kwargs['username'],
+                    "HUBOT_IRC_SERVER": "localhost",
+                    "HUBOT_IRC_ROOMS": "#stackstorm",
+                    "HUBOT_IRC_NICK": kwargs['username'],
                 })
                 config["hubot::dependencies"]["hubot-irc"] = ">=0.2.7 < 1.0.0"
             elif kwargs["chatops"] == "irc":
                 config["hubot::adapter"] = "irc"
                 config["hubot::env_export"].update({
-                    "HUBOT_IRC_SERVER":   kwargs["irc-server"],
-                    "HUBOT_IRC_ROOMS":    kwargs["irc-rooms"],
-                    "HUBOT_IRC_NICK":     kwargs['irc-nick'],
+                    "HUBOT_IRC_SERVER": kwargs["irc-server"],
+                    "HUBOT_IRC_ROOMS": kwargs["irc-rooms"],
+                    "HUBOT_IRC_NICK": kwargs['irc-nick'],
                 })
 
                 # Optional arguments
@@ -249,11 +258,14 @@ class RootController(BaseController):
                 if kwargs["irc-password"] != "":
                     config["hubot::env_export"]["HUBOT_IRC_PASSWORD"] = kwargs["irc-password"]
                 if kwargs["irc-nickserv-password"] != "":
-                    config["hubot::env_export"]["HUBOT_IRC_NICKSERV_PASSWORD"] = kwargs["irc-nickserv-password"]
+                    config["hubot::env_export"]["HUBOT_IRC_NICKSERV_PASSWORD"] = \
+                        kwargs["irc-nickserv-password"]
                 if kwargs["irc-nickserv-username"] != "":
-                    config["hubot::env_export"]["HUBOT_IRC_NICKSERV_USERNAME"] = kwargs["irc-nickserv-username"]
+                    config["hubot::env_export"]["HUBOT_IRC_NICKSERV_USERNAME"] = \
+                        kwargs["irc-nickserv-username"]
                 if "irc-server-fake-ssl" in kwargs:
-                    config["hubot::env_export"]["HUBOT_IRC_SERVER_FAKE_SSL"] = kwargs["irc-server-fake-ssl"]
+                    config["hubot::env_export"]["HUBOT_IRC_SERVER_FAKE_SSL"] = \
+                        kwargs["irc-server-fake-ssl"]
                 if "irc-usessl" in kwargs:
                     config["hubot::env_export"]["HUBOT_IRC_USESSL"] = kwargs["irc-usessl"]
                 if "irc-unflood" in kwargs:
@@ -263,9 +275,9 @@ class RootController(BaseController):
             elif kwargs["chatops"] == "flowdock":
                 config["hubot::adapter"] = "flowdock"
                 config["hubot::env_export"].update({
-                    "HUBOT_FLOWDOCK_API_TOKEN":       kwargs["flowdock-token"],
-                    "HUBOT_FLOWDOCK_LOGIN_EMAIL":     kwargs["flowdock-email"],
-                    "HUBOT_FLOWDOCK_LOGIN_PASSWORD":  kwargs['flowdock-password']
+                    "HUBOT_FLOWDOCK_API_TOKEN": kwargs["flowdock-token"],
+                    "HUBOT_FLOWDOCK_LOGIN_EMAIL": kwargs["flowdock-email"],
+                    "HUBOT_FLOWDOCK_LOGIN_PASSWORD": kwargs['flowdock-password']
                 })
                 config["hubot::dependencies"]["hubot-flowdock"] = ">=0.7.6 < 1.0.0"
             elif kwargs["chatops"] == "slack":
@@ -299,10 +311,10 @@ class RootController(BaseController):
         if not os.path.exists(self.path):
             os.makedirs(self.path)
 
-        if not os.access(self.path+self.configname, os.W_OK):
+        if not os.access(self.path + self.configname, os.W_OK):
             Popen(self.grant_access, shell=True).wait()
 
-        with open(self.path+self.configname, 'w') as workroom:
+        with open(self.path + self.configname, 'w') as workroom:
             workroom.write(json.dumps(config))
 
         self.config_written = True
@@ -317,14 +329,19 @@ class RootController(BaseController):
     @expose(generic=True, template='progress.html')
     def install(self):
         if self.config_written:
+            if "hubot::adapter" in self.config:
+                chatops = self.config["hubot::adapter"]
+            else:
+                chatops = "Disabled"
             return {"hostname": self.hostname,
                     "config": self.config,
                     "gen_ssl": self.gen_ssl,
                     "gen_ssh": self.gen_ssh,
-                    "chatops": (self.config["hubot::adapter"] if "hubot::adapter" in self.config else "Disabled")}
+                    "chatops": chatops}
         else:
             redirect('/', internal=True)
 
     @expose(generic=True, template='byob.html')
     def byob(self):
-        return {"hostname": (self.hostname or request.host.split(':')[0]), "password": self.password}
+        return {"hostname": (self.hostname or request.host.split(':')[0]),
+                "password": self.password}

--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -76,10 +76,6 @@ class RootController(BaseController):
         elif self.puppet_check():
             redirect('/wait', internal=True)
 
-    def get_enterprise_token(self):
-        # Hardcoded for now
-        return "token"
-
     @expose(content_type='text/plain')
     def cleanup(self):
         for command in self.cleanup_chain:
@@ -157,7 +153,6 @@ class RootController(BaseController):
         password = kwargs['hubot-password']
 
         collect_anonymous_data = True if "anon-data" in kwargs else False
-        token = self.get_enterprise_token if "enterprise" in kwargs else ""
 
         uuid = str(uuid1())
 
@@ -172,7 +167,7 @@ class RootController(BaseController):
             "st2::cli_auth_url": "https://%s:9100" % kwargs['hostname'],
 
             "st2::stanley::username": kwargs['username'],
-            "st2enterprise::token": token,
+
             "users": {
                 kwargs['admin-username']: {
                     "password": kwargs['password-1'],
@@ -213,6 +208,9 @@ class RootController(BaseController):
         else:
             config["st2::stanley::ssh_private_key"] = kwargs['gen-private']
             config["st2::stanley::ssh_public_key"] = kwargs['gen-public']
+
+        if kwargs["enterprise"] != "":
+            config["st2enterprise::token"] = kwargs["enterprise"]
 
         if "check-chatops" in kwargs and kwargs["check-chatops"] == "1":
 

--- a/st2installer/templates/index.html
+++ b/st2installer/templates/index.html
@@ -32,8 +32,12 @@
     </fieldset>
 
     <h2>StackStorm Enterprise</h2>
-    <p>Try <a href="http://stackstorm.com/product/#enterprise" target="_blank">StackStorm Enterprise Edition</a> for 30 days, featuring LDAP integration, role-based access control, visual workflow editor and more. No payment or credit card necessary, no strings attached. After the trial expires StackStorm will revert to Community Edition automatically.</p>
-    <label for="check-enterprise"><input id="check-enterprise" type="checkbox" name="enterprise" value="1" checked="checked">Enable 30 days StackStorm Enterprise trial</label>
+    <p class="enter-pi">StackStorm Enterprise features LDAP integration, role-based access control, a visual workflow editor, and more. Enter your license key to activate Enterprise Edition, or <a href="http://stackstorm.com/product/#enterprise" target="_blank">request a 30 day free trial</a>.</p>
+    <label for="ch-enterprise"><input id="ch-enterprise" type="checkbox" name="ch-enterprise" value="1" checked="checked">Enable enterprise features</label>
+    <div id="license-key">
+      <label for="check-enterprise">License key</label>
+      <input id="check-enterprise" type="text" name="enterprise" value="" />
+    </div>
 
   </div>
   <div class="page" id="page-accounts">

--- a/st2installer/templates/index.html
+++ b/st2installer/templates/index.html
@@ -31,6 +31,10 @@
       </div>
     </fieldset>
 
+    <h2>StackStorm Enterprise</h2>
+    <p>Try <a href="http://stackstorm.com/product/#enterprise" target="_blank">StackStorm Enterprise Edition</a> for 30 days, featuring LDAP integration, role-based access control, visual workflow editor and more. No payment or credit card necessary, no strings attached. After the trial expires StackStorm will revert to Community Edition automatically.</p>
+    <label for="check-enterprise"><input id="check-enterprise" type="checkbox" name="enterprise" value="1" checked="checked">Enable 30 days StackStorm Enterprise trial</label>
+
   </div>
   <div class="page" id="page-accounts">
     <h1>Setup user accounts</h1>

--- a/st2installer/templates/progress.html
+++ b/st2installer/templates/progress.html
@@ -6,7 +6,7 @@
 <input type="hidden" id="ga-ssh" name="ga-ssh" value="${gen_ssh}" />
 <input type="hidden" id="ga-ssl" name="ga-ssl" value="${gen_ssl}" />
 
-<div class="page done" id="page-puppet">
+<div class="page progress" id="page-puppet">
   <h1>Installation</h1>
 
   <p class="progress">StackStorm is preparing for the first launch! Installation will take a few more minutes.</p>

--- a/st2installer/templates/progress.html
+++ b/st2installer/templates/progress.html
@@ -1,4 +1,4 @@
-<%inherit file="layout.html"/>
+﻿<%inherit file="layout.html"/>
 
 <%block name="stepcount"/>
 
@@ -6,9 +6,12 @@
 <input type="hidden" id="ga-ssh" name="ga-ssh" value="${gen_ssh}" />
 <input type="hidden" id="ga-ssl" name="ga-ssl" value="${gen_ssl}" />
 
-<div class="page" id="page-puppet">
+<div class="page done" id="page-puppet">
   <h1>Installation</h1>
-  <p>StackStorm is preparing for the first launch! Installation will take a few more minutes.</p>
+
+  <p class="progress">StackStorm is preparing for the first launch! Installation will take a few more minutes.</p>
+  <p class="done">Congratulations, StackStorm installation is completed! You can review the full log below.</p>
+
   <div id="warning-count">
     <span id="warnings">0</span> warning<span id="warnings-plural">s</span>, <span id="errors">0</span> error<span id="errors-plural">s</span>.
     <div id="filtering">
@@ -25,27 +28,40 @@
 
     </div>
   </div>
-  <div id="puppet-done">
-    <p>Installation completed; StackStorm is ready to launch! Review the documentation before you start:</p>
+  <div id="rootca-warning">
+    <h4><i class="fa fa-exclamation-triangle"></i> StackStorm Root CA</h4>
+    <p>Because you're using a self-signed SSL certificate, you need to install StackStorm Root CA in order for UI and API to communicate:</p>
     <ul>
-      <li><a href="http://stackstorm.com" target="_blank">Main website</a></li>
-      <li><a href="https://github.com/StackStorm" target="_blank">Github</a></li>
-      <li><a href="https://www.youtube.com/channel/UCColc5CuBJ8-1SnALnkDz8Q" target="_blank">YouTube channel</a></li>
-      <li><a href="http://stackstorm.com/blog" target="_blank">Blog</a></li>
+      <li><a href="/ssl/st2_root_ca.cer" target="_blank">Download your Root CA</a></li>
+      <li><a href="http://wiki.cacert.org/FAQ/ImportRootCert" target="_blank">Read the installation manual on CAcert wiki</a></li>
     </ul>
+    <p>Safety notice: this CA was automatically generated on your server, it's not shared across different StackStorm installations nor is it accessible by anyone but you. Remember never to share your private keys with anyone!</p>
+  </div>
 
-    <div id="rootca-warning">
-      <h4><i class="fa fa-exclamation-triangle"></i> StackStorm Root CA</h4>
-      <p>Because you're using a self-signed SSL certificate, you need to install StackStorm Root CA in order for UI and API to communicate:</p>
-      <ul>
-        <li><a href="/ssl/st2_root_ca.cer" target="_blank">Download your Root CA</a></li>
-        <li><a href="http://wiki.cacert.org/FAQ/ImportRootCert" target="_blank">Read the installation manual on CAcert wiki</a></li>
-      </ul>
-      <p>Safety notice: this CA was automatically generated on your server, it's not shared across different StackStorm installations nor is it accessible by anyone but you. Never share it with anyone except users of your StackStorm instance.</p>
-    </div>
+  <p class="done">Lastly, before you begin, here are some useful links to get you started with StackStorm and its amazing community:</p>
 
-    <div id="next-button">
-      <a href="https://${hostname}" id="step-next">Open StackStorm</a>
-    </div>
+  <div class="done" id="puppet-done">
+    <ul>
+      <li><a href="http://docs.stackstorm.com" target="_blank">
+        <i class="fa fa-folder-open"></i> Documentation</a>
+      </li>
+      <li><a href="https://stackstorm.com/community-signup" target="_blank">
+        <i class="fa fa-slack"></i> Slack community</a>
+      </li>
+      <li><a href="https://stackstorm.com/video-gallery/" target="_blank">
+        <i class="fa fa-play-circle"></i> Video gallery</a>
+      </li>
+      <li><a href="https://stackstorm.com/blog" target="_blank">
+        <i class="fa fa-rss"></i> StackStorm blog</a>
+      </li>
+    </ul>
+  </div>
+
+  <p class="signature done">Time to launch your newly-configured instance now! We hope you have a great time using it, and we're always ready to help should you have any questions.
+    <em>— StackStorm team</em>
+  </p>
+
+  <div class="done" id="next-button">
+    <a href="https://${hostname}" id="step-next">Open StackStorm</a>
   </div>
 </div>

--- a/st2installer/tests/test_functional.py
+++ b/st2installer/tests/test_functional.py
@@ -1,9 +1,8 @@
-from pecan.testing import load_test_app
-from copy import copy
 import os
 import re
-
 from st2installer.tests.base import BaseTestCase
+from pecan.testing import load_test_app
+from copy import copy
 
 
 class FunctionalTest(BaseTestCase):
@@ -16,7 +15,10 @@ class FunctionalTest(BaseTestCase):
         ))
 
         self.public_regex = re.compile("^ssh-rsa AAAA[0-9A-Za-z+/]+[=]{0,3}( ([^@]+@[^@]+))?$")
-        self.private_regex = re.compile("^-----BEGIN RSA PRIVATE KEY-----.*-----END RSA PRIVATE KEY-----$", re.DOTALL)
+        self.private_regex = re.compile(
+            "^-----BEGIN RSA PRIVATE KEY-----.*-----END RSA PRIVATE KEY-----$",
+            re.DOTALL
+        )
         self.default_post = {
             'hostname': 'localhost-test',
             'check-chatops': '1',
@@ -41,9 +43,9 @@ class FunctionalTest(BaseTestCase):
         valid_string = ('good' if valid else 'bad')
         public_extension = ('pub' if type is 'ssh' else 'crt')
         if key == 'private':
-            return path+('/%s-%s.key') % (type, valid_string)
+            return path + ('/%s-%s.key') % (type, valid_string)
         if key == 'public':
-            return path+('/%s-%s.%s') % (type, valid_string, public_extension)
+            return path + ('/%s-%s.%s') % (type, valid_string, public_extension)
 
     def test_main_page(self):
         response = self.app.get('/')
@@ -103,7 +105,7 @@ class FunctionalTest(BaseTestCase):
         response = self.app.get('/keypair/keygen')
         body = response.json
         self.assertEqual(response.status_int, 200)
-        self.assertTrue(self.public_regex.match('ssh-rsa '+body['public']))
+        self.assertTrue(self.public_regex.match('ssh-rsa ' + body['public']))
         self.assertTrue(self.private_regex.match(body['private']))
 
     def test_keypair_gen_key_pair_is_generated_on_demand(self):
@@ -113,7 +115,7 @@ class FunctionalTest(BaseTestCase):
             response = self.app.get('/keypair/keygen')
             body = response.json
             self.assertEqual(response.status_int, 200)
-            self.assertTrue(self.public_regex.match('ssh-rsa '+body['public']))
+            self.assertTrue(self.public_regex.match('ssh-rsa ' + body['public']))
             self.assertTrue(self.private_regex.match(body['private']))
 
             self.assertTrue(body['private'] not in seen_private_keys)
@@ -121,7 +123,8 @@ class FunctionalTest(BaseTestCase):
         self.assertEqual(len(seen_private_keys), 3)
 
     def test_root_datasave(self):
-        response = self.app.get('/data_save', params={'hostname': 'new-hostname-test', 'password': 'new-password-test'})
+        response = self.app.get('/data_save', params={'hostname': 'new-hostname-test',
+                                                      'password': 'new-password-test'})
         self.assertEqual(response.status_int, 204)
         main_page = self.app.get('/')
         self.assertIn('new-hostname-test', main_page.body)

--- a/st2installer/tests/test_units.py
+++ b/st2installer/tests/test_units.py
@@ -1,6 +1,4 @@
 import os
-from st2installer.controllers.root import RootController
-
 from st2installer.tests.base import BaseTestCase
 
 
@@ -9,10 +7,10 @@ class MainUnits(BaseTestCase):
         path = os.path.dirname(__file__)
         valid_string = ('good' if valid else 'bad')
         public_extension = ('pub' if type is 'ssh' else 'crt')
-        with open(path+('/%s-%s.key') % (type, valid_string), 'r') as private_file:
-            private = private_file.read()
-        with open(path+('/%s-%s.%s') % (type, valid_string, public_extension), 'r') as public_file:
-            public = public_file.read()
+        with open(path + ('/%s-%s.key') % (type, valid_string), 'r') as private_f:
+            private = private_f.read()
+        with open(path + ('/%s-%s.%s') % (type, valid_string, public_extension), 'r') as public_f:
+            public = public_f.read()
         return (private, public)
 
     def test_temp_files_are_writable(self):
@@ -61,7 +59,6 @@ class MainUnits(BaseTestCase):
                                                         private,
                                                         public)
         self.assertEqual('0\n', keypair_valid)
-
 
     def test_bad_ssh_keys_fail(self):
         (private, public) = self.get_keypair('ssh', False)

--- a/test/output.py
+++ b/test/output.py
@@ -1,16 +1,18 @@
 #!/usr/bin/python
 
-import sys, random, time
+import sys
+import random
+import time
 
 # A sample app for UI testing that just throws some output to stdout and stderr.
 
-# First we need to make sure the output is composed of 
+# First we need to make sure the output is composed of
 # some great, meaningful words.
 dictionary = [
-  'automation', 'openstack', 'big data', 'cloud-based',
-  'disruptive', 'innovation', 'petabyte', 'scalable',
-  'gamificaton', 'synergy', 'enterprise', 'data-driven',
-  'crowdsourcing', 'real-time', 'pivot', 'remediation' 
+    'automation', 'openstack', 'big data', 'cloud-based',
+    'disruptive', 'innovation', 'petabyte', 'scalable',
+    'gamificaton', 'synergy', 'enterprise', 'data-driven',
+    'crowdsourcing', 'real-time', 'pivot', 'remediation'
 ]
 
 # Parameters for total runtime, warning/error frequency (every N lines).
@@ -23,15 +25,15 @@ word_count = 4
 # Throw random lines.
 
 for line in range(total_lines):
-  sb = ''
-  if line>0 and not (line % warning_frequency):
-    sb += 'WARNING: '
-  elif line>0 and not (line % error_frequency):
-    sb += 'ERROR: '
-  for word in range(word_count):
-    sb += '%s ' % random.choice(dictionary)
-  if line>0 and not (line % (total_lines/5)):
-    sys.stdout.write("PROGRESS: %i\n" % (100/float(total_lines)*line))
-  sys.stdout.write("%s\n" % sb)
-  sys.stdout.flush()
-  time.sleep(line_pause)
+    sb = ''
+    if line > 0 and not (line % warning_frequency):
+        sb += 'WARNING: '
+    elif line > 0 and not (line % error_frequency):
+        sb += 'ERROR: '
+    for word in range(word_count):
+        sb += '%s ' % random.choice(dictionary)
+    if line > 0 and not (line % (total_lines / 5)):
+        sys.stdout.write("PROGRESS: %i\n" % (100 / float(total_lines) * line))
+    sys.stdout.write("%s\n" % sb)
+    sys.stdout.flush()
+    time.sleep(line_pause)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 100
+ignore = E128,E402
+exclude=build/*,*.egg/*,*env/*


### PR DESCRIPTION
1. "StackStorm Enterprise" section in the first tab:
![enterprise](https://cloud.githubusercontent.com/assets/145218/10455892/c5da83c6-71c6-11e5-88d9-de57def0038e.png)
Checkbox state is written to "st2enterprise::token": if checked, `get_enterprise_token` method is evaluated; if not, an empty string is passed.

2. Installation progress page rework: a bit more love to the links and some minor changes.
![install](https://cloud.githubusercontent.com/assets/145218/10455985/5f123d2c-71c7-11e5-9ab4-afb26b760f5a.png)

3. Lots of linting: python is linted with `flake8`, js is linted with `jshint`.

Change as necessary: I think the wording has to be adjusted on the progress page. Also, I tried to make a separate "after install" page and found the experience a bit strange, so I just reworked links and element order instead. I think what we have now is good.

I'm also not sure if I have to write an empty string to "st2enterprise::token" or just don't have that key in config at all.

Lastly, @jfryman asked me to put a message about evaluating enterprise on the last page if the user hasn't ticked the box in the beginning:

> If a user did not enter a license key, they should have a link to some enterprise comparison page.

I think it's better to provide this link right next to the checkbox (see the first screenshot) to help with the decision, because on the last page it doesn't make a lot of sense: St2 is already installed and deployed, so it's too late to reconsider, right? Even if somebody does reconsider, what do we offer? Re-running puppet? I'm unsure about that scenario, so, again, I've put the link and a small description next to the enterprise checkbox. We can extend it later if necessary.

@jfryman @DoriftoShoes please review. :)