### PR TITLE
Making license key field disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ Now you can access installer at `http://localhost:9090/`. Be aware that it locks
 
 ## Versioning
 
-The installer is versioned in `config.py` as `X.Y.Z`. Z needs to be incremented with a backend change or a bugfix, Y needs to be incremented with any UI/UX changes, X is incremented with a major release. Point of versioning is to provide sectioned analytics.
+The installer is versioned in `config.py` as `X.Y.Z`. It's loosely based on Semantic Versioning, with the notable exception that every UI change—no matter how small—never should be a "patch" (`Z`) increment, minor (or major) only. In every other case follow SemVer and use your best judgement; St2Installer is a critical dependency for most St2 installations, so a proper way of reflecting backwards-incompatible changes is necessary.

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ app = {
         404: '/error/404',
         '__force_dict__': True
     },
-    'version': '0.0.1'
+    'version': '0.1.0'
 }
 
 logging = {

--- a/st2installer/templates/index.html
+++ b/st2installer/templates/index.html
@@ -34,10 +34,10 @@
 
     <h2>StackStorm Enterprise</h2>
     <p class="enter-pi">StackStorm Enterprise features LDAP integration, role-based access control, a visual workflow editor, and more. Enter your license key to activate Enterprise Edition, or <a href="http://stackstorm.com/product/#enterprise" target="_blank">request a 30 day free trial</a>.</p>
-    <label for="ch-enterprise"><input id="ch-enterprise" type="checkbox" name="ch-enterprise" value="1" checked="checked">Enable enterprise features</label>
+    <label for="ch-enterprise"><input id="ch-enterprise" type="checkbox" name="ch-enterprise" value="1">Enable enterprise features</label>
     <div id="license-key">
       <label for="check-enterprise">License key</label>
-      <input id="check-enterprise" type="text" name="enterprise" value="" />
+      <input id="check-enterprise" type="text" name="enterprise" value="" disabled="disabled" />
     </div>
 
   </div>

--- a/st2installer/tests/config.py
+++ b/st2installer/tests/config.py
@@ -14,8 +14,7 @@ app = {
     'errors': {
         '404': '/error/404',
         '__force_dict__': True
-    },
-    'version': '0.0.1'
+    }
 }
 
 puppet = {


### PR DESCRIPTION
As @dzimine requested, making license key disabled by default to avoid confusion.

Also, clarified the readme for the versioning system to make things a bit more clear.