### PR TITLE
Disable debug in prod config

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ app = {
     'modules': ['st2installer'],
     'static_root': '%(confdir)s/public',
     'template_path': '%(confdir)s/st2installer/templates',
-    'debug': True,
+    'debug': False,
     'errors': {
         404: '/error/404',
         '__force_dict__': True


### PR DESCRIPTION
We should only enable debug for local development - we can do that using a separate config for a local development.