### PR TITLE
Reimplementing cleanup logic

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -67,7 +67,6 @@ var puppet = {
   line: 0,
   interval: 700,
   url: 'puppet',
-  cleanup: 'cleanup',
   set_progress: function(p) {
     puppet.progress = p;
     $('#progressbar>span').width(p+'%');
@@ -165,7 +164,6 @@ var puppet = {
       .removeClass('progress')
       .addClass('done');
     $('#puppet-done').show();
-    $.get(puppet.cleanup);
     $.ajax({
       type: 'HEAD',
       url: '/ssl/st2_root_ca.cer',

--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -88,7 +88,7 @@ class RootController(BaseController):
                 Popen(command, shell=True).wait()
             except CalledProcessError as e:
                 errors.append(e)
-        return errors if errors else True
+        return errors or True
 
     @expose(content_type='text/plain')
     def puppet(self, line):

--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -113,6 +113,7 @@ class RootController(BaseController):
                 self.runtime = (time.time() - self.start_time)
                 data += '--terminate--'
                 data += str(self.runtime)
+
         if not data:
             return '--idle--'
 

--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -112,10 +112,10 @@ class RootController(BaseController):
             else:
                 cleanup = self.cleanup()
                 if cleanup is not True:
-                    data += 'ERROR: Cleanup failure!'
-                    data += ''.join(cleanup)
+                    data += 'ERROR: Cleanup failure!' + '\n'
+                    data += '\n'.join(cleanup)
                 self.runtime = (time.time() - self.start_time)
-                data += '--terminate--'
+                data += '\n--terminate--'
                 data += str(self.runtime)
 
         if not data:


### PR DESCRIPTION
1. Restart docker-hubot from cleanup
2. Calling cleanup when puppet is done regardless of what happens in the UI
3. Chaining cleanup commands instead of executing in parallel
4. Outputting cleanup errors into the console