### PR TITLE
Fixing the redirect loop

### DIFF
--- a/st2installer/templates/progress.html
+++ b/st2installer/templates/progress.html
@@ -2,9 +2,11 @@
 
 <%block name="stepcount"/>
 
+% if sent == False:
 <input type="hidden" id="ga-chatops" name="ga-chatops" value="${chatops}" />
 <input type="hidden" id="ga-ssh" name="ga-ssh" value="${gen_ssh}" />
 <input type="hidden" id="ga-ssl" name="ga-ssl" value="${gen_ssl}" />
+% endif
 <input type="hidden" id="sent" name="sent" value="${sent}" />
 
 <div class="page progress" id="page-puppet">


### PR DESCRIPTION
One issue we had starting from, um, I don’t even know when is being unable to access the installer page after the install is done. That’s a regression, because it wasn’t like this at the beginning, but I guess nobody just cared much. :P

This PR fixes it: when you refresh the installer or open another install page in parallel, you’ll get the same log, and nothing will be run twice. When you open the installer after everything’s done, you’ll get the success message and the full log.

This is a pre-req to fixing the UI being unable to tell when the install is complete in some cases.