### PR TITLE
A milder CA message

### DIFF
--- a/st2installer/templates/progress.html
+++ b/st2installer/templates/progress.html
@@ -31,7 +31,7 @@
   </div>
   <div id="rootca-warning">
     <h4><i class="fa fa-exclamation-triangle"></i> StackStorm Root CA</h4>
-    <p>Because you're using a self-signed SSL certificate, you need to install StackStorm Root CA in order for UI and API to communicate:</p>
+    <p>Because you're using a self-signed SSL certificate, the installer has generated a Certificate Authority. You can download it here to add to the local trust store or to distribute to StackStorm users:</p>
     <ul>
       <li><a href="/ssl/st2_root_ca.cer" target="_blank">Download your Root CA</a></li>
       <li><a href="http://wiki.cacert.org/FAQ/ImportRootCert" target="_blank">Read the installation manual on CAcert wiki</a></li>


### PR DESCRIPTION
Toned down the message a bit, because the CA is advised rather than required now that we have single-port deployment.