### PR TITLE
Reload the page on consecutive access errors

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -65,6 +65,7 @@ var puppet = {
   errors: 0,
   warnings: 0,
   line: 0,
+  access_errors: 0,
   interval: 700,
   url: 'puppet',
   set_progress: function(p) {
@@ -98,6 +99,7 @@ var puppet = {
       data: {line: puppet.line},
       timeout: 500,
       success: function(res, status, data) {
+        puppet.access_errors = 0;
         data = String(data.responseText);
         if (data != '--idle--' && status != 'timeout') {
           lines = data.split('\n');
@@ -150,6 +152,12 @@ var puppet = {
               }
             }
           }
+        }
+      },
+      error: function() {
+        puppet.access_errors += 1;
+        if (puppet.access_errors > 5) {
+          location.reload();
         }
       },
       complete: function(data, status) {


### PR DESCRIPTION
This PR solves the problem of installer not being able to finish, because the HTTPS certificate changes mid-flight and the logs can’t be accessed anymore, which means there’s no indication of install finishing.

Now the UI reloads on five consecutive log access errors. In case with certificate changing this would mean that the user will be prompted to accept a new cerificate on reload, and the install will continue.

Needs #90 to ensure smooth continuation.