### PR TITLE
Fix for the convergence bug (run puppet twice)

### DIFF
--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -103,11 +103,15 @@ class RootController(BaseController):
             self.start_time = time.time()
 
         data = ''
-        logfile = open(self.output, 'r')
-        for i, logline in enumerate(logfile):
-            if i >= int(line):
-                data += logline.strip() + '\n'
-        logfile.close()
+
+        try:
+            logfile = open(self.output, 'r')
+
+            for i, logline in enumerate(logfile):
+                if i >= int(line):
+                    data += logline.strip() + '\n'
+        finally:
+            logfile.close()
 
         if self.proc.poll() is not None:
             data += '--terminate--'


### PR DESCRIPTION
There is a weird bug with puppet and GUI installer where the system doesn't fully converge on the initial puppet run.

Initially we thought this is only related to RBAC since this is one of the things which doesn't fully converge on the initial run, but it turns out there are other things which only fully converge on second run (pack permissions, setting postgres password, etc.).

We haven't been able to track down and fix the root cause and bug yet so we are left with the best option we have so far. That is a work around which includes running `puprun` inside the installer loop twice.

"Good" news is that in theory you could run puprun as many times as you want and as long as you use the same code and answer.json files the result should be the same (well, the whole cfg management and convergence theory is based around that).

The full list of issue this fixes it he diff between https://gist.github.com/Kami/912d313972c01cca1f08 (first puppet run) and https://gist.github.com/Kami/4671085b135f5feb4602 (second puppet run).