### PR TITLE
Use a script to run puppet and add support for debug

### DIFF
--- a/scripts/run-puppet.sh
+++ b/scripts/run-puppet.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env sh
 
-if [ -n "$DEBUG" ]; then
-    PUPPET_DEBUG_ARGS="--debug --verbose"
-else
-    PUPPET_DEBUG_ARGS=""
-fi
+# Note: We enable DEBUG mode by default so we get more useful info
+PUPPET_DEBUG_ARGS="--debug --verbose"
 
 # Command used to invoke puppet run
 COMMAND="/usr/bin/sudo FACTER_installer_running=true ENV=current_working_directory NOCOLOR=true /usr/bin/puprun ${PUPPET_DEBUG_ARGS}"

--- a/scripts/run-puppet.sh
+++ b/scripts/run-puppet.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+
+if [ -n "$DEBUG" ]; then
+    PUPPET_DEBUG_ARGS="--debug --verbose"
+else
+    PUPPET_DEBUG_ARGS=""
+fi
+
+# Command used to invoke puppet run
+COMMAND="/usr/bin/sudo FACTER_installer_running=true ENV=current_working_directory NOCOLOR=true /usr/bin/puprun ${PUPPET_DEBUG_ARGS}"
+
+# Note: There is a weird bug with convergence on Ubuntu where some
+# some tasks don't converge on initial puppet run (RBAC definitions,
+# pack resource permissions, etc.)so we run it twice.
+# Keep in mind that this is an ugly work around because we haven't
+# been able to track down the root cause.
+
+# Note: Log file is emptied inside the installer so appending (>>) is fine
+echo "Running command: ${COMMAND}"
+${COMMAND}
+
+echo "Running command: ${COMMAND}"
+${COMMAND}
+
+EXIT_CODE=$?
+exit ${EXIT_CODE}

--- a/scripts/run-puppet.sh
+++ b/scripts/run-puppet.sh
@@ -11,7 +11,7 @@ COMMAND="/usr/bin/sudo FACTER_installer_running=true ENV=current_working_directo
 
 # Note: There is a weird bug with convergence on Ubuntu where some
 # some tasks don't converge on initial puppet run (RBAC definitions,
-# pack resource permissions, etc.)so we run it twice.
+# pack resource permissions, etc.) so we run it twice.
 # Keep in mind that this is an ugly work around because we haven't
 # been able to track down the root cause.
 

--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -14,9 +14,10 @@ from st2installer.controllers.base import BaseController
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 SCRIPTS_DIR = os.path.abspath(os.path.join(BASE_DIR, '../../scripts'))
 
-class RootController(BaseController):
 
+class RootController(BaseController):
     def __init__(self, config=None):
+        config = config or {}
 
         self.proc = None
         self.st2stop = '/usr/bin/sudo /usr/bin/st2ctl stop'
@@ -35,14 +36,20 @@ class RootController(BaseController):
         self.version = None
 
         config = config or conf.to_dict()
-        if 'app' in config and 'version' in config['app']:
-            self.version = config['app']['version']
-        if 'puppet' in config and 'command' in config['puppet']:
-            self.command = config['puppet']['command']
+
+        version = config.get('app', {}).get('version', None)
+        if version:
+            self.version = version
+
+        puppet_command = config.get('puppet', {}).get('command', None)
+        if puppet_command:
+            self.command = puppet_command
         else:
             self.command = os.path.join(SCRIPTS_DIR, 'run-puppet.sh')
-        if 'puppet' in config and 'hieradata' in config['puppet']:
-            self.path = config['puppet']['hieradata']
+
+        hieradata_path = config.get('puppet', {}).get('hieradata', None)
+        if hieradata_path:
+            self.path = hieradata_path
         else:
             self.path = "/opt/puppet/hieradata/"
 

--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -11,13 +11,8 @@ import json
 import pipes
 from st2installer.controllers.base import BaseController
 
-# Command which is used to run puppet
-# TODO: Add support for debug mode and args
-PUPPET_RUN_COMMAND = ('/usr/bin/sudo '
-    'FACTER_installer_running=true '
-    'ENV=current_working_directory '
-    'NOCOLOR=true /usr/bin/puprun')
-
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+SCRIPTS_DIR = os.path.abspath(os.path.join(BASE_DIR, '../../scripts'))
 
 class RootController(BaseController):
 
@@ -45,12 +40,7 @@ class RootController(BaseController):
         if 'puppet' in config and 'command' in config['puppet']:
             self.command = config['puppet']['command']
         else:
-            # Note: There is a weird bug with convergence on Ubuntu where some
-            # some tasks don't converge on initial puppet run (RBAC definitions,
-            # pack resource permissions, etc.)so we run it twice.
-            # Keep in mind that this is an ugly work around because we haven't
-            # been able to track down the root cause.
-            self.command = '; '.join([PUPPET_RUN_COMMAND, PUPPET_RUN_COMMAND])
+            self.command = os.path.join(SCRIPTS_DIR, 'run-puppet.sh')
         if 'puppet' in config and 'hieradata' in config['puppet']:
             self.path = config['puppet']['hieradata']
         else:


### PR DESCRIPTION
Using script makes it easier for us to add logging, etc.

In addition to that, I added support for debug.