### PR TITLE
hardcode ssh_key_type to ssh-rsa

### DIFF
--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -34,6 +34,8 @@ class RootController(BaseController):
         self.gen_ssl = 'Self-signed'
         self.gen_ssh = 'Generated'
         self.version = None
+        # we only support ssh-rsa key types
+        self.ssh_key_type = 'ssh-rsa'
 
         config = config or conf.to_dict()
 
@@ -245,6 +247,7 @@ class RootController(BaseController):
         else:
             config["st2::stanley::ssh_public_key"] = kwargs['gen-public']
             config["st2::stanley::ssh_private_key"] = kwargs['gen-private']
+            config["st2::stanley::ssh_key_type"] = self.ssh_key_type
 
         if "enterprise" in kwargs and kwargs["enterprise"] != "":
             config["st2enterprise::token"] = kwargs["enterprise"]


### PR DESCRIPTION
* this assumption is clearly spelled out in the docs and ssh_key_type is required
  as per https://github.com/StackStorm/puppet-st2/blob/5c4a3fcf66e69853136cabb62aa5ca365033022c/manifests/user.pp#L72