### PR TITLE
Force reload: fix redirect loop

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -156,12 +156,12 @@ var puppet = {
       },
       error: function() {
         puppet.access_errors += 1;
-        if (puppet.access_errors > 5) {
-          location.reload();
+        if (puppet.access_errors > 10) {
+          location.reload(true);
         }
       },
       complete: function(data, status) {
-        if (puppet.progress < 100) {
+        if (puppet.progress < 100 && puppet.access_errors <= 10) {
           setTimeout(puppet.read, puppet.interval);
         }
       }


### PR DESCRIPTION
Today’s best effort at fixing the dreadful Installer Redirect Loop. This is a multi-part fix:

1. Apparently different browsers treat “insecure response” differently, and refreshing with `force` flag makes things slightly better.

2. We terminate polling altogether once the critical number of errors has been reached. This was the main cause of the loop: if the refresh takes longer than a second, another polling takes place and another refresh starts before the previous one could execute. This is dead simple, but forced reloads was the thing that actually helped me reliably track this.

3. There is an issue when nginx+installer reload actually takes longer than 5 seconds. That’s what happens in this case: a redirect fires, a blank log screen shows up, then times out, then another redirect fires. It’s purely cosmetic, and there’s no point in fixing it now, but I increased the timeout to 10 seconds so that this issue pops up less often.

I feel like we shouldn’t put any more effort into it until we start shipping packages and switch to bash. There’s still a cosmetic multi-timeout issue (3), but it’s much better than what we had before. It works. Any more fixing before we fix the underlying cause would just be an unreasonable waste of time.