### PR TITLE
Revert "Escaping special chars in Hubot env params"

### DIFF
--- a/st2installer/controllers/root.py
+++ b/st2installer/controllers/root.py
@@ -8,7 +8,6 @@ import random
 import string
 import os
 import json
-import pipes
 from st2installer.controllers.base import BaseController
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -333,9 +332,6 @@ class RootController(BaseController):
                     config["hubot::env_export"]["HUBOT_XMPP_HOST"] = kwargs["xmpp-host"]
                 if kwargs["xmpp-port"] != "":
                     config["hubot::env_export"]["HUBOT_XMPP_PORT"] = kwargs["xmpp-port"]
-
-            for key, value in config["hubot::env_export"].iteritems():
-                config["hubot::env_export"][key] = pipes.quote(value)
 
         if not os.path.exists(self.path):
             os.makedirs(self.path)


### PR DESCRIPTION
Reverts StackStorm/st2installer#95

Escaping env variable at that point does not fixes the problem with special characters instead introduces another one related to the quotes which breaks hipchat adapter in different ways. The right way to do the escaping would be to quote every env variable in workroom at the point the command is constructed.